### PR TITLE
Use unification fork and update linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+testing-report.html
 
 # Translations
 *.mo

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,372 @@
+[MASTER]
+# Use multiple processes to speed up Pylint.
+jobs=0
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality.
+optimize-ast=no
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=all
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+enable=import-error,
+       import-self,
+       reimported,
+       wildcard-import,
+       misplaced-future,
+       relative-import,
+       deprecated-module,
+       unpacking-non-sequence,
+       invalid-all-object,
+       undefined-all-variable,
+       used-before-assignment,
+       cell-var-from-loop,
+       global-variable-undefined,
+       dangerous-default-value,
+       # redefined-builtin,
+       redefine-in-handler,
+       unused-import,
+       unused-wildcard-import,
+       global-variable-not-assigned,
+       undefined-loop-variable,
+       global-at-module-level,
+       bad-open-mode,
+       redundant-unittest-assert,
+       boolean-datetime,
+       # unused-variable
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=parseable
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,input
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=yes
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[ELIF]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=tensorflow.core.framework,tensorflow.python.framework,tensorflow.python.ops.gen_linalg_ops
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set). This supports can work
+# with qualified names.
+ignored-classes=
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=optparse
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,17 @@ dist: xenial
 language: python
 
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
-  - "pypy3.5"
+  - "3.8"
+  - "pypy3"
 
 install:
   - pip install -r requirements-dev.txt
   - pip install -e ./
 
 script:
-  - flake8 cons tests
+  - pylint cons/ tests/
   - if [[ `command -v black` ]]; then
       black --check cons tests;
     fi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,68 @@
+.PHONY: help venv conda docker docstyle format style black test lint check coverage
+.DEFAULT_GOAL = help
+
+PYTHON = python
+PIP = pip
+CONDA = conda
+SHELL = bash
+
+help:
+	@printf "Usage:\n"
+	@grep -E '^[a-zA-Z_-]+:.*?# .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?# "}; {printf "\033[1;34mmake %-10s\033[0m%s\n", $$1, $$2}'
+
+conda:  # Set up a conda environment for development.
+	@printf "Creating conda environment...\n"
+	${CONDA} create --yes --name cons-env python=3.6
+	( \
+	${CONDA} activate cons-env; \
+	${PIP} install -U pip; \
+	${PIP} install -e ./; \
+	${PIP} install -r requirements-dev.txt; \
+	${CONDA} deactivate; \
+	)
+	@printf "\n\nConda environment created! \033[1;34mRun \`conda activate cons-env\` to activate it.\033[0m\n\n\n"
+
+venv:  # Set up a Python virtual environment for development.
+	@printf "Creating Python virtual environment...\n"
+	rm -rf cons-venv
+	${PYTHON} -m venv cons-venv
+	( \
+	source cons-venv/bin/activate; \
+	${PIP} install -U pip; \
+	${PIP} install -e ./; \
+	${PIP} install -r requirements-dev.txt; \
+	deactivate; \
+	)
+	@printf "\n\nVirtual environment created! \033[1;34mRun \`source cons-venv/bin/activate\` to activate it.\033[0m\n\n\n"
+
+docker:  # Set up a Docker image for development.
+	@printf "Creating Docker image...\n"
+	${SHELL} ./scripts/container.sh --build
+
+docstyle:
+	@printf "Checking documentation with pydocstyle...\n"
+	pydocstyle cons/
+	@printf "\033[1;34mPydocstyle passes!\033[0m\n\n"
+
+format:
+	@printf "Checking code style with black...\n"
+	black --check cons/
+	@printf "\033[1;34mBlack passes!\033[0m\n\n"
+
+style:
+	@printf "Checking code style with pylint...\n"
+	pylint cons/ tests/
+	@printf "\033[1;34mPylint passes!\033[0m\n\n"
+
+black:  # Format code in-place using black.
+	black cons/ tests/
+
+test:  # Test code using pytest.
+	pytest -v tests/ --cov=cons/ --cov-report=xml --html=testing-report.html --self-contained-html
+
+coverage: test
+	diff-cover coverage.xml --compare-branch=master --fail-under=100
+
+lint: docstyle format style  # Lint code using pydocstyle, black and pylint.
+
+check: lint test coverage  # Both lint and test code. Runs `make lint` followed by `make test`.

--- a/cons/core.py
+++ b/cons/core.py
@@ -163,8 +163,7 @@ class MaybeConsType(ABCMeta):
 
 
 class MaybeCons(metaclass=MaybeConsType):
-    """A class used to dynamically determine potential cons types from
-    non-ConsPairs.
+    """A class used to dynamically determine potential cons types from non-ConsPairs.
 
     For example,
 
@@ -173,6 +172,7 @@ class MaybeCons(metaclass=MaybeConsType):
 
     The potential cons types are drawn from the implemented `cdr` dispatch
     functions.
+
     """
 
     @abstractmethod

--- a/cons/unify.py
+++ b/cons/unify.py
@@ -1,5 +1,6 @@
 from itertools import tee
-from collections import OrderedDict, Iterator
+from collections import OrderedDict
+from collections.abc import Iterator, Mapping
 
 from unification.core import unify, _unify, reify, _reify
 
@@ -28,16 +29,16 @@ def _cons_unify(lcons, rcons, s):
     return False
 
 
-_unify.add((ConsPair, (ConsPair, MaybeCons), dict), _cons_unify)
-_unify.add((MaybeCons, ConsPair, dict), _cons_unify)
+_unify.add((ConsPair, (ConsPair, MaybeCons), Mapping), _cons_unify)
+_unify.add((MaybeCons, ConsPair, Mapping), _cons_unify)
 
 
-@_reify.register(OrderedDict, dict)
+@_reify.register(OrderedDict, Mapping)
 def reify_OrderedDict(od, s):
     return OrderedDict((k, reify(v, s)) for k, v in od.items())
 
 
-@_reify.register(ConsPair, dict)
+@_reify.register(ConsPair, Mapping)
 def reify_cons(lcons, s):
     rcar = reify(car(lcons), s)
     rcdr = reify(cdr(lcons), s)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
-pytest-cov
-pytest>=3.6
-coverage
-flake8
-black; python_version >= '3.6'
+pydocstyle>=3.0.0
+pytest>=5.0.0
+pytest-cov>=2.6.1
+pytest-html>=1.20.0
+pylint>=2.3.1
+black>=19.3b0; platform.python_implementation!='PyPy'
+diff-cover

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,10 @@
+[pydocstyle]
+# Ignore errors for missing docstrings.
+# Ignore D202 (No blank lines allowed after function docstring)
+# due to bug in black: https://github.com/ambv/black/issues/355
+add-ignore = D100,D101,D102,D103,D104,D105,D106,D107,D202
+convention = numpy
+
 [tool:pytest]
-filterwarnings =
-    ignore:Using or importing the ABCs from 'collections':DeprecationWarning:unification.core
 python_files=test*.py
 testpaths=tests

--- a/setup.py
+++ b/setup.py
@@ -4,24 +4,22 @@ from setuptools import find_packages, setup
 
 setup(
     name="cons",
-    version="0.1.3",
+    version="0.2.0",
     install_requires=[
-        'toolz',
-        'unification'
+        "toolz",
+        "unification @ git+https://github.com/brandonwillard/unification.git@master#egg=unification-0.2.2",
     ],
-    packages=find_packages(exclude=['tests']),
-    tests_require=[
-        'pytest'
-    ],
+    packages=find_packages(exclude=["tests"]),
+    tests_require=["pytest"],
     author="Brandon T. Willard",
     author_email="brandonwillard+cons@gmail.com",
     description="""An implementation of Lisp/Scheme-like cons in Python.""",
-    long_description=open('README.md').read() if exists("README.md") else "",
-    long_description_content_type='text/markdown',
+    long_description=open("README.md").read() if exists("README.md") else "",
+    long_description_content_type="text/markdown",
     license="LGPL-3",
     url="https://github.com/brandonwillard/python-cons",
-    platforms=['any'],
-    python_requires='>=3.5',
+    platforms=["any"],
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",
@@ -31,11 +29,10 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries",
-    ]
+    ],
 )

--- a/tests/test_cons.py
+++ b/tests/test_cons.py
@@ -236,8 +236,11 @@ def test_unification():
 
     # This is only if we allow `None` to signify all/any empty collection,
     # while--somewhat controversially--we let it default to `[]`.
-    res = unify((1,), cons(1, None), {})
+    res = unify([1], cons(1, None), {})
     assert res == {}
+
+    res = unify((1,), cons(1, None), {})
+    assert res is False
 
     res = unify(cons(1, 2), cons(car_lv, 2), {})
     assert res == {car_lv: 1}


### PR DESCRIPTION
Use an updated fork of `unification`, update the linter, and add a Makefile for more convenient style and coverage checking.